### PR TITLE
format antlr4 grammars using antlr4Formatter

### DIFF
--- a/antlr4-formatter-standalone/src/main/java/com/khubla/antlr4formatter/StandaloneFormatter.java
+++ b/antlr4-formatter-standalone/src/main/java/com/khubla/antlr4formatter/StandaloneFormatter.java
@@ -66,6 +66,5 @@ public class StandaloneFormatter {
       System.exit(1);
    }
 
-   private StandaloneFormatter() {
-   }
+   private StandaloneFormatter() {}
 }

--- a/antlr4-formatter/src/main/antlr4/ANTLRv4Lexer.g4
+++ b/antlr4-formatter/src/main/antlr4/ANTLRv4Lexer.g4
@@ -40,13 +40,19 @@ lexer grammar ANTLRv4Lexer;
 options { superClass = LexerAdaptor; }
 import LexBasic;
 // Standard set of fragments
+
 tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }
 channels { OFF_CHANNEL , COMMENT }
 // ======================================================
+
 // Lexer specification
+
 //
+
 // -------------------------
+
 // Comments
+
 DOC_COMMENT
    : DocComment
    ;
@@ -59,20 +65,28 @@ LINE_COMMENT
    : LineComment -> channel (COMMENT)
    ;
    // -------------------------
+   
    // Integer
+   
    //
-
+   
 INT
    : DecimalNumeral
    ;
    // -------------------------
+   
    // Literal string
+   
    //
+   
    // ANTLR makes no distinction between a single character literal and a
+   
    // multi-character string. All literals are single quote delimited and
+   
    // may contain unicode escape sequences of the form \uxxxx, where x
+   
    // is a valid hexadecimal number (per Unicode standard).
-
+   
 STRING_LITERAL
    : SQuoteLiteral
    ;
@@ -81,29 +95,40 @@ UNTERMINATED_STRING_LITERAL
    : USQuoteLiteral
    ;
    // -------------------------
+   
    // Arguments
+   
    //
+   
    // Certain argument lists, such as those specifying call parameters
+   
    // to a rule invocation, or input parameters to a rule specification
+   
    // are contained within square brackets.
-
+   
 BEGIN_ARGUMENT
    : LBrack
    { handleBeginArgument(); }
    ;
    // -------------------------
+   
    // Actions
-
+   
 BEGIN_ACTION
    : LBrace -> pushMode (Action)
    ;
    // -------------------------
+   
    // Keywords
+   
    //
+   
    // Keywords may not be used as labels for rules or in any other context where
+   
    // they would be ambiguous with the keyword vs some other identifier.  OPTIONS,
+   
    // TOKENS, & CHANNELS blocks are handled idiomatically in dedicated lexical modes.
-
+   
 OPTIONS
    : 'options' -> pushMode (Options)
    ;
@@ -172,8 +197,9 @@ MODE
    : 'mode'
    ;
    // -------------------------
+   
    // Punctuation
-
+   
 COLON
    : Colon
    ;
@@ -266,40 +292,57 @@ NOT
    : Tilde
    ;
    // -------------------------
+   
    // Identifiers - allows unicode rule/token names
-
+   
 ID
    : Id
    ;
    // -------------------------
+   
    // Whitespace
-
+   
 WS
    : Ws+ -> channel (OFF_CHANNEL)
    ;
    // -------------------------
+   
    // Illegal Characters
+   
    //
+   
    // This is an illegal character trap which is always the last rule in the
+   
    // lexer specification. It matches a single character of any value and being
+   
    // the last rule in the file will match when no other rule knows what to do
+   
    // about the character. It is reported as an error but is not passed on to the
+   
    // parser. This means that the parser to deal with the gramamr file anyway
+   
    // but we will not try to analyse or code generate from a file with lexical
+   
    // errors.
+   
    //
+   
    // Comment this rule out to allow the error to be propagated to the parser
-
+   
 ERRCHAR
    : . -> channel (HIDDEN)
    ;
    // ======================================================
+   
    // Lexer modes
+   
    // -------------------------
+   
    // Arguments
-
+   
 mode Argument;
 // E.g., [int x, List<String> a[]]
+
 NESTED_ARGUMENT
    : LBrack -> type (ARGUMENT_CONTENT) , pushMode (Argument)
    ;
@@ -321,7 +364,7 @@ END_ARGUMENT
    { handleEndArgument(); }
    ;
    // added this to return non-EOF token type here. EOF does something weird
-
+   
 UNTERMINATED_ARGUMENT
    : EOF -> popMode
    ;
@@ -330,15 +373,23 @@ ARGUMENT_CONTENT
    : .
    ;
    // -------------------------
+   
    // Actions
+   
    //
+   
    // Many language targets use {} as block delimiters and so we
+   
    // must recursively match {} delimited blocks to balance the
+   
    // braces. Additionally, we must make some assumptions about
+   
    // literal string representation in the target language. We assume
+   
    // that they are delimited by ' or " and so consume these
+   
    // in their own alts so as not to inadvertantly match {}.
-
+   
 mode Action;
 NESTED_ACTION
    : LBrace -> type (ACTION_CONTENT) , pushMode (Action)
@@ -381,7 +432,7 @@ ACTION_CONTENT
    : .
    ;
    // -------------------------
-
+   
 mode Options;
 OPT_DOC_COMMENT
    : DocComment -> type (DOC_COMMENT) , channel (COMMENT)
@@ -435,7 +486,7 @@ OPT_WS
    : Ws+ -> type (WS) , channel (OFF_CHANNEL)
    ;
    // -------------------------
-
+   
 mode Tokens;
 TOK_DOC_COMMENT
    : DocComment -> type (DOC_COMMENT) , channel (COMMENT)
@@ -473,9 +524,10 @@ TOK_WS
    : Ws+ -> type (WS) , channel (OFF_CHANNEL)
    ;
    // -------------------------
-
+   
 mode Channels;
 // currently same as Tokens mode; distinguished by keyword
+
 CHN_DOC_COMMENT
    : DocComment -> type (DOC_COMMENT) , channel (COMMENT)
    ;
@@ -512,7 +564,7 @@ CHN_WS
    : Ws+ -> type (WS) , channel (OFF_CHANNEL)
    ;
    // -------------------------
-
+   
 mode LexerCharSet;
 LEXER_CHAR_SET_BODY
    : (~ [\]\\] | EscAny)+ -> more
@@ -526,8 +578,9 @@ UNTERMINATED_CHAR_SET
    : EOF -> popMode
    ;
    // ------------------------------------------------------------------------------
+   
    // Grammar specific Keywords, Punctuation, etc.
-
+   
 fragment Id
    : NameStartChar NameChar*
    ;

--- a/antlr4-formatter/src/main/antlr4/ANTLRv4Parser.g4
+++ b/antlr4-formatter/src/main/antlr4/ANTLRv4Parser.g4
@@ -42,6 +42,7 @@ parser grammar ANTLRv4Parser;
 
 options { tokenVocab = ANTLRv4Lexer; }
 // The main entry point for parsing a v4 grammar.
+
 grammarSpec
    : DOC_COMMENT* grammarDecl prequelConstruct* rules modeSpec* EOF
    ;
@@ -54,9 +55,11 @@ grammarType
    : (LEXER GRAMMAR | PARSER GRAMMAR | GRAMMAR)
    ;
    // This is the list of all constructs that can be declared before
+   
    // the set of rules that compose the grammar, and is invoked 0..n
+   
    // times by the grammarPrequel rule.
-
+   
 prequelConstruct
    : optionsSpec
    | delegateGrammars
@@ -65,8 +68,9 @@ prequelConstruct
    | action_
    ;
    // ------------
+   
    // Options - things that affect analysis and/or code generation
-
+   
 optionsSpec
    : OPTIONS LBRACE (option SEMI)* RBRACE
    ;
@@ -82,8 +86,9 @@ optionValue
    | INT
    ;
    // ------------
+   
    // Delegates
-
+   
 delegateGrammars
    : IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
    ;
@@ -93,8 +98,9 @@ delegateGrammar
    | identifier
    ;
    // ------------
+   
    // Tokens & Channels
-
+   
 tokensSpec
    : TOKENS LBRACE idList? RBRACE
    ;
@@ -107,12 +113,12 @@ idList
    : identifier (COMMA identifier)* COMMA?
    ;
    // Match stuff like @parser::members {int i;}
-
+   
 action_
    : AT (actionScopeName COLONCOLON)? identifier actionBlock
    ;
    // Scope names could collide with keywords; allow them as ids for action scopes
-
+   
 actionScopeName
    : identifier
    | LEXER
@@ -165,8 +171,9 @@ ruleReturns
    : RETURNS argActionBlock
    ;
    // --------------
+   
    // Exception spec
-
+   
 throwsSpec
    : THROWS identifier (COMMA identifier)*
    ;
@@ -183,12 +190,17 @@ ruleModifiers
    : ruleModifier+
    ;
    // An individual access modifier for a rule. The 'fragment' modifier
+   
    // is an internal indication for lexer rules that they do not match
+   
    // from the input but are like subroutines for other lexer rules to
+   
    // reuse for certain lexical patterns. The other modifiers are passed
+   
    // to the code generation templates and may be ignored by the template
+   
    // if they are of no use in that language.
-
+   
 ruleModifier
    : PUBLIC
    | PRIVATE
@@ -208,8 +220,9 @@ labeledAlt
    : alternative (POUND identifier)?
    ;
    // --------------------
+   
    // Lexer rules
-
+   
 lexerRuleSpec
    : DOC_COMMENT* FRAGMENT? TOKEN_REF COLON lexerRuleBlock SEMI
    ;
@@ -226,6 +239,7 @@ lexerAlt
    : lexerElements lexerCommands?
    |
    // explicitly allow empty alts
+   
    ;
 
 lexerElements
@@ -239,7 +253,7 @@ lexerElement
    | actionBlock QUESTION?
    ;
    // but preds can be anywhere
-
+   
 labeledLexerElement
    : identifier (ASSIGN | PLUS_ASSIGN) (lexerAtom | lexerBlock)
    ;
@@ -248,7 +262,7 @@ lexerBlock
    : LPAREN lexerAltList RPAREN
    ;
    // E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
-
+   
 lexerCommands
    : RARROW lexerCommand (COMMA lexerCommand)*
    ;
@@ -268,8 +282,9 @@ lexerCommandExpr
    | INT
    ;
    // --------------------
+   
    // Rule Alts
-
+   
 altList
    : alternative (OR alternative)*
    ;
@@ -278,6 +293,7 @@ alternative
    : elementOptions? element+
    |
    // explicitly allow empty alts
+   
    ;
 
 element
@@ -291,8 +307,9 @@ labeledElement
    : identifier (ASSIGN | PLUS_ASSIGN) (atom | block)
    ;
    // --------------------
+   
    // EBNF and blocks
-
+   
 ebnf
    : block blockSuffix?
    ;
@@ -322,8 +339,9 @@ atom
    | DOT elementOptions?
    ;
    // --------------------
+   
    // Inverted element set
-
+   
 notSet
    : NOT setElement
    | NOT blockSet
@@ -340,20 +358,23 @@ setElement
    | LEXER_CHAR_SET
    ;
    // -------------
+   
    // Grammar Block
-
+   
 block
    : LPAREN (optionsSpec? ruleAction* COLON)? altList RPAREN
    ;
    // ----------------
+   
    // Parser rule ref
-
+   
 ruleref
    : RULE_REF argActionBlock? elementOptions?
    ;
    // ---------------
+   
    // Character Range
-
+   
 characterRange
    : STRING_LITERAL RANGE STRING_LITERAL
    ;
@@ -363,8 +384,9 @@ terminal
    | STRING_LITERAL elementOptions?
    ;
    // Terminals may be adorned with certain options when
+   
    // reference in the grammar: TOK<,,,>
-
+   
 elementOptions
    : LT elementOption (COMMA elementOption)* GT
    ;

--- a/antlr4-formatter/src/main/antlr4/LexBasic.g4
+++ b/antlr4-formatter/src/main/antlr4/LexBasic.g4
@@ -35,9 +35,13 @@
  */
 lexer grammar LexBasic;
 // ======================================================
+
 // Lexer fragments
+
 //
+
 // -----------------------------------
+
 // Whitespace & Comments
 
 fragment Ws
@@ -65,9 +69,11 @@ fragment LineComment
    : '//' ~ [\r\n]*
    ;
    // -----------------------------------
+   
    // Escapes
+   
    // Any kind of escaped character that we can embed within ANTLR literal strings.
-
+   
 fragment EscSeq
    : Esc ([btnfr"'\\] | UnicodeEsc | . | EOF)
    ;
@@ -80,15 +86,17 @@ fragment UnicodeEsc
    : 'u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?
    ;
    // -----------------------------------
+   
    // Numerals
-
+   
 fragment DecimalNumeral
    : '0'
    | [1-9] DecDigit*
    ;
    // -----------------------------------
+   
    // Digits
-
+   
 fragment HexDigit
    : [0-9a-fA-F]
    ;
@@ -97,8 +105,9 @@ fragment DecDigit
    : [0-9]
    ;
    // -----------------------------------
+   
    // Literals
-
+   
 fragment BoolLiteral
    : 'true'
    | 'false'
@@ -120,8 +129,9 @@ fragment USQuoteLiteral
    : SQuote (EscSeq | ~ ['\r\n\\])*
    ;
    // -----------------------------------
+   
    // Character ranges
-
+   
 fragment NameChar
    : NameStartChar
    | '0' .. '9'
@@ -147,15 +157,18 @@ fragment NameStartChar
    | '\uFDF0' .. '\uFFFD'
    ;
    // ignores | ['\u10000-'\uEFFFF] ;
+   
    // -----------------------------------
+   
    // Types
-
+   
 fragment Int
    : 'int'
    ;
    // -----------------------------------
+   
    // Symbols
-
+   
 fragment Esc
    : '\\'
    ;

--- a/antlr4-formatter/src/main/antlr4/LexUnicode.g4
+++ b/antlr4-formatter/src/main/antlr4/LexUnicode.g4
@@ -35,7 +35,9 @@
  */
 lexer grammar LexUnicode;
 // ======================================================
+
 // Lexer fragments
+
 //
 
 fragment UnicodeLetter

--- a/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/Antlr4Formatter.java
+++ b/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/Antlr4Formatter.java
@@ -145,6 +145,5 @@ public class Antlr4Formatter {
       return files;
    }
 
-   private Antlr4Formatter() {
-   }
+   private Antlr4Formatter() {}
 }

--- a/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/Antlr4FormatterListenerImpl.java
+++ b/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/Antlr4FormatterListenerImpl.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.antlr.parser.antlr4.ANTLRv4Parser.ArgActionBlockContext;
 import org.antlr.parser.antlr4.ANTLRv4Parser.ActionBlockContext;
+import org.antlr.parser.antlr4.ANTLRv4Parser.ArgActionBlockContext;
 import org.antlr.parser.antlr4.ANTLRv4Parser.GrammarDeclContext;
 import org.antlr.parser.antlr4.ANTLRv4Parser.LexerRuleSpecContext;
 import org.antlr.parser.antlr4.ANTLRv4Parser.ModeSpecContext;
@@ -47,7 +47,8 @@ public class Antlr4FormatterListenerImpl implements FormatterListener {
     *
     * @author tom
     */
-   public static enum IndentType {
+   public static enum IndentType
+   {
       tab, space
    }
 

--- a/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/listener/FormatterListener.java
+++ b/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/listener/FormatterListener.java
@@ -26,7 +26,8 @@ public interface FormatterListener extends ParseTreeListener {
     *
     * @author tom
     */
-   public static enum CommentType {
+   public static enum CommentType
+   {
       block, line
    }
 

--- a/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/listener/FormatterParseTreeListenerImpl.java
+++ b/antlr4-formatter/src/main/java/com/khubla/antlr4formatter/listener/FormatterParseTreeListenerImpl.java
@@ -42,7 +42,7 @@ public class FormatterParseTreeListenerImpl implements ParseTreeListener {
    /**
     * comment tokens
     */
-   private static final Set<String> commentTokens = new HashSet<>(Arrays.asList(new String[] { "/*", "//" }));
+   private static final Set<String> commentTokens = new HashSet<>(Arrays.asList(new String[]{"/*", "//"}));
    /**
     * formatter
     */

--- a/antlr4-formatter/src/test/java/com/khubla/antlr4formatter/Antlr4FormatterTest.java
+++ b/antlr4-formatter/src/test/java/com/khubla/antlr4formatter/Antlr4FormatterTest.java
@@ -139,7 +139,6 @@ public class Antlr4FormatterTest {
       testFormatterIdempotence("CSharpPreprocessorParser.unformatted.g4", "CSharpPreprocessorParser.formatted.g4");
    }
 
-
    @Test
    public void testLastToken() throws Antlr4FormatterException, IOException {
       testGrammar("lasttoken.unformatted.g4", "lasttoken.formatted.g4");

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<junit.version>4.12</junit.version>
 		<assertj.version>3.12.2</assertj.version>
-		<spotless.version>1.17.0</spotless.version>
+		<spotless.version>2.0.0</spotless.version>
 	</properties>
 
 	<dependencies>
@@ -110,6 +110,12 @@
 							<file>${maven.multiModuleProjectDirectory}/format.importorder</file>
 						</importOrder>
 					</java>
+
+					<antlr4>
+						<antlr4Formatter>
+							<version>1.2.1</version>
+						</antlr4Formatter>
+					</antlr4>
 
 					<formats>
 						<format>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
 					<encoding>UTF-8</encoding>
 
 					<java>
+						<includes>
+							<include>src/main/java/**/*.java</include>
+							<include>src/test/java/**/*.java</include>
+						</includes>
+
 						<eclipse>
 							<file>${maven.multiModuleProjectDirectory}/format.eclipse.xml</file>
 							<version>4.7.1</version>


### PR DESCRIPTION
This PR solves #23 and adds formatting of antlr4 grammars to the spotless goal.

Using `./mvnw spotless:check` the formatting can be validated.
Using `./mvnw spotless:apply` the valid formatting can be applied.